### PR TITLE
[oneDNN] Prevent oversubscription with oneDNN threads

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1485,6 +1485,7 @@ endif()
 
 if (onnxruntime_USE_DNNL)
   include(dnnl)
+  add_compile_definitions(DNNL_OPENMP)
 endif()
 
 # TVM EP

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -555,6 +555,11 @@ if (onnxruntime_USE_DNNL)
     target_include_directories(onnxruntime_providers_dnnl PRIVATE ${ORTTRAINING_ROOT})
   endif()
 
+  # Needed for threadpool handling
+  if(onnxruntime_BUILD_JAVA)
+    add_compile_definitions(DNNL_JAVA)
+  endif()
+
   if(APPLE)
     set_property(TARGET onnxruntime_providers_dnnl APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker -exported_symbols_list ${ONNXRUNTIME_ROOT}/core/providers/dnnl/exported_symbols.lst")
     set_target_properties(onnxruntime_providers_dnnl PROPERTIES

--- a/include/onnxruntime/core/providers/dnnl/dnnl_provider_factory.h
+++ b/include/onnxruntime/core/providers/dnnl/dnnl_provider_factory.h
@@ -8,9 +8,10 @@ extern "C" {
 #endif
 
 /**
- * \param use_arena zero: false. non-zero: true.
+ * \param[in] dnnl_options configuration parameters for oneDnnl EP creation.
  */
-ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_Dnnl, _In_ OrtSessionOptions* options, int use_arena);
+ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_Dnnl,
+               _In_ OrtSessionOptions* options, _In_ const OrtDnnlProviderOptions* dnnl_options);
 
 #ifdef __cplusplus
 }

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -557,6 +557,18 @@ typedef struct OrtOpenVINOProviderOptions {
   unsigned char enable_dynamic_shapes;  ///< 0 = disabled, nonzero = enabled
 } OrtOpenVINOProviderOptions;
 
+/** \brief OneDNN Provider Options
+ *
+ * \see OrtApi::SessionOptionsAppendExecutionProvider_Dnnl
+ */
+typedef struct OrtDnnlProviderOptions {
+#ifdef __cplusplus
+  OrtDnnlProviderOptions() : use_arena{true}, threadpool_args{nullptr} {}
+#endif
+  int use_arena;          // If arena is used, use_arena 0 = not used, nonzero = used
+  void* threadpool_args;  // Used to enable ORT threadpool when using the test runner
+} OrtDnnlProviderOptions;
+
 struct OrtApi;
 typedef struct OrtApi OrtApi;
 

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -410,9 +410,12 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addDnn
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint useArena) {
     (void)jobj;
   #ifdef USE_DNNL
-    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,OrtSessionOptionsAppendExecutionProvider_Dnnl((OrtSessionOptions*) handle,useArena));
-  #else
-    (void)apiHandle;(void)handle;(void)useArena; // Parameters used when DNNL is defined.
+    OrtDnnlProviderOptions dnnl_options;
+    dnnl_options.use_arena = useArena;  // Follow the user command
+    checkOrtStatus(jniEnv, (const OrtApi*)apiHandle,
+                   OrtSessionOptionsAppendExecutionProvider_Dnnl((OrtSessionOptions*)handle, &dnnl_options));
+#else
+    (void)apiHandle; (void)handle; (void)useArena; // Parameters used when DNNL is defined.
     throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with DNNL support.");
   #endif
 }

--- a/onnxruntime/core/providers/dnnl/dnnl_execution_provider.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_execution_provider.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <memory>
 #include <map>
 #include <list>
+#include <memory>
 #include <memory.h>
 
-#include "core/platform/ort_mutex.h"
-#include "dnnl_op_manager.h"
+#include "core/providers/dnnl/dnnl_threadpool.h"
+#include "core/providers/dnnl/dnnl_op_manager.h"
 #include "core/providers/dnnl/subgraph/dnnl_subgraph.h"
 #include "core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h"
 
@@ -18,9 +18,11 @@ namespace onnxruntime {
 // Information needed to construct DNNL execution providers.
 struct DNNLExecutionProviderInfo {
   bool create_arena{true};
+  void* threadpool_args{nullptr};
 
   explicit DNNLExecutionProviderInfo(bool use_arena)
-      : create_arena(use_arena) {}
+      : create_arena(use_arena),
+        threadpool_args(threadpool_args) {}
   DNNLExecutionProviderInfo() = default;
 };
 

--- a/onnxruntime/core/providers/dnnl/dnnl_provider_factory.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_provider_factory.cc
@@ -1,36 +1,44 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/providers/shared_library/provider_api.h"
 #include "core/providers/dnnl/dnnl_provider_factory.h"
+
 #include <atomic>
 #include <cassert>
-#include "dnnl_execution_provider.h"
-#include "dnnl_provider_factory_creator.h"
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/dnnl/dnnl_provider_factory_creator.h"
+#include "core/providers/dnnl/dnnl_execution_provider.h"
 
 using namespace onnxruntime;
 
 namespace onnxruntime {
 
 struct DnnlProviderFactory : IExecutionProviderFactory {
-  DnnlProviderFactory(bool create_arena) : create_arena_(create_arena) {}
+  DnnlProviderFactory(bool create_arena,
+                      void* threadpool_args)
+      : create_arena_(create_arena),
+        threadpool_args_(threadpool_args) {}
+
   ~DnnlProviderFactory() override {}
 
   std::unique_ptr<IExecutionProvider> CreateProvider() override;
 
  private:
   bool create_arena_;
+  void* threadpool_args_;
 };
 
 std::unique_ptr<IExecutionProvider> DnnlProviderFactory::CreateProvider() {
   DNNLExecutionProviderInfo info;
   info.create_arena = create_arena_;
+  info.threadpool_args = threadpool_args_;
   return std::make_unique<DNNLExecutionProvider>(info);
 }
 
 struct Dnnl_Provider : Provider {
-  std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory(int use_arena) override {
-#if defined(_WIN32)
+  std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory(const void* options) override {
+#if defined(DNNL_OPENMP) && defined(_WIN32)
     {
       // We crash when unloading DNNL on Windows when OpenMP also unloads (As there are threads
       // still running code inside the openmp runtime DLL if OMP_WAIT_POLICY is set to ACTIVE).
@@ -40,12 +48,16 @@ struct Dnnl_Provider : Provider {
       constexpr const char* dll_name = "vcomp140d.dll";
 #else
       constexpr const char* dll_name = "vcomp140.dll";
-#endif
+#endif // _DEBUG
       ::GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_PIN, dll_name, &handle);
       assert(handle);  // It should exist
     }
-#endif
-    return std::make_shared<DnnlProviderFactory>(use_arena != 0);
+#endif  // defined(DNNL_OPENMP) && defined(_WIN32)
+    // Cast options
+    const OrtDnnlProviderOptions* dnnl_options = reinterpret_cast<const OrtDnnlProviderOptions*>(options);
+
+    return std::make_shared<DnnlProviderFactory>(dnnl_options->use_arena != 0,
+                                                 dnnl_options->threadpool_args);
   }
 
   void Initialize() override {

--- a/onnxruntime/core/providers/dnnl/dnnl_provider_factory_creator.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_provider_factory_creator.h
@@ -7,9 +7,11 @@
 
 #include "core/providers/providers.h"
 
+struct OrtDnnlProviderOptions;
+
 namespace onnxruntime {
 // defined in provider_bridge_ort.cc
 struct DnnlProviderFactoryCreator {
-  static std::shared_ptr<IExecutionProviderFactory> Create(int use_arena);
+  static std::shared_ptr<IExecutionProviderFactory> Create(const OrtDnnlProviderOptions* dnnl_options);
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/dnnl_threadpool.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_threadpool.h
@@ -1,0 +1,32 @@
+// Copyright(C) 2022 Intel Corporation
+// Licensed under the MIT License
+#pragma once
+
+#include <algorithm>
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+#include <thread>
+
+inline int DnnlCalcNumThreads() {
+  int num_threads = 0;
+#if _WIN32
+  // Indeed 64 should be enough. However, it's harmless to have a little more.
+  SYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer[256];
+  DWORD returnLength = sizeof(buffer);
+  if (GetLogicalProcessorInformation(buffer, &returnLength) == FALSE) {
+    num_threads = std::thread::hardware_concurrency();
+  } else {
+    int count = (int)(returnLength / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
+    for (int i = 0; i != count; ++i) {
+      if (buffer[i].Relationship == RelationProcessorCore) {
+        ++num_threads;
+      }
+    }
+  }
+#endif
+  if (!num_threads)
+    num_threads = std::thread::hardware_concurrency();
+
+  return num_threads;
+}

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1202,8 +1202,9 @@ CannProviderFactoryCreator::Create(const OrtCANNProviderOptions* provider_option
   return s_library_cann.Get().CreateExecutionProviderFactory(provider_options);
 }
 
-std::shared_ptr<IExecutionProviderFactory> DnnlProviderFactoryCreator::Create(int use_arena) {
-  return s_library_dnnl.Get().CreateExecutionProviderFactory(use_arena);
+std::shared_ptr<IExecutionProviderFactory>
+DnnlProviderFactoryCreator::Create(const OrtDnnlProviderOptions* dnnl_options) {
+  return s_library_dnnl.Get().CreateExecutionProviderFactory(dnnl_options);
 }
 
 std::shared_ptr<IExecutionProviderFactory> TensorrtProviderFactoryCreator::Create(int device_id) {
@@ -1372,9 +1373,11 @@ ProviderOptions GetProviderInfo_Cuda(const OrtCUDAProviderOptionsV2* provider_op
 
 }  // namespace onnxruntime
 
-ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_Dnnl, _In_ OrtSessionOptions* options, int use_arena) {
+ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_Dnnl, 
+                    _In_ OrtSessionOptions* options,
+                    _In_ const OrtDnnlProviderOptions* dnnl_options) {
   API_IMPL_BEGIN
-  auto factory = onnxruntime::DnnlProviderFactoryCreator::Create(use_arena);
+  auto factory = onnxruntime::DnnlProviderFactoryCreator::Create(dnnl_options);
   if (!factory) {
     return OrtApis::CreateStatus(ORT_FAIL, "OrtSessionOptionsAppendExecutionProvider_Dnnl: Failed to load shared library");
   }

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -597,7 +597,32 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
 #endif
   } else if (type == kDnnlExecutionProvider) {
 #ifdef USE_DNNL
-    return onnxruntime::DnnlProviderFactoryCreator::Create(session_options.enable_cpu_mem_arena)->CreateProvider();
+    // Generate dnnl_options
+    OrtDnnlProviderOptions dnnl_options;
+// For Eigen and OpenMP
+#if !defined(DNNL_ORT_THREAD)
+    int num_threads = 0;
+    auto it = provider_options_map.find(type);
+    if (it != provider_options_map.end()) {
+      for (auto option : it->second) {
+        if (option.first == "num_of_threads") {
+          num_threads = std::stoi(option.second);
+          if (num_threads < 0) {
+            ORT_THROW(
+                "[ERROR] [OneDNN] Invalid entry for the key 'num_of_threads',"
+                " set number of threads or use '0' for default\n");
+            // If the user doesnt define num_threads, auto detect threads later
+          }
+        } else {
+          ORT_THROW("Invalid OneDNN EP option: ", option.first);
+        }
+      }
+    }
+    dnnl_options.threadpool_args = static_cast<void*>(&num_threads);
+#endif  // !defined(DNNL_ORT_THREAD)
+    dnnl_options.use_arena = session_options.enable_cpu_mem_arena;
+
+    return onnxruntime::DnnlProviderFactoryCreator::Create(&dnnl_options)->CreateProvider();
 #endif
   } else if (type == kOpenVINOExecutionProvider) {
 #ifdef USE_OPENVINO

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -488,7 +488,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Tensor
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_MIGraphX(const OrtMIGraphXProviderOptions* params);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_MIGraphX(int device_id);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Cuda(const OrtCUDAProviderOptions* params);
-std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int use_arena);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(const OrtDnnlProviderOptions* params);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(const OrtOpenVINOProviderOptions* params);
 #ifdef USE_TVM
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Tvm(const tvm::TvmEPOptions& info);

--- a/onnxruntime/test/global_thread_pools/test_inference.cc
+++ b/onnxruntime/test/global_thread_pools/test_inference.cc
@@ -74,7 +74,8 @@ static Ort::Session GetSessionObj(Ort::Env& env, T model_uri, int provider_type)
 #endif
   } else if (provider_type == 2) {
 #ifdef USE_DNNL
-    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, 1));
+    OrtDnnlProviderOptions dnnl_options;
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &dnnl_options));
     std::cout << "Running simple inference with dnnl provider" << std::endl;
 #else
     return Ort::Session(nullptr);

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -377,7 +377,13 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_dnnl) {
 #ifdef USE_DNNL
-      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(sf, enable_cpu_mem_arena ? 1 : 0));
+      // Generate dnnl_options to optimize dnnl performance
+      OrtDnnlProviderOptions dnnl_options;
+      dnnl_options.use_arena = enable_cpu_mem_arena ? 1 : 0;
+#if defined(DNNL_ORT_THREAD)
+      dnnl_options.threadpool_args = static_cast<void*>(TestEnv::GetDefaultThreadPool(Env::Default()));
+#endif  // defined(DNNL_ORT_THREAD)
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(sf, &dnnl_options));
 #else
       fprintf(stderr, "DNNL is not supported in this build");
       return -1;

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -39,9 +39,53 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
   const std::string& provider_name = performance_test_config.machine_config.provider_type_name;
   if (provider_name == onnxruntime::kDnnlExecutionProvider) {
 #ifdef USE_DNNL
+    // Generate provider options
+    OrtDnnlProviderOptions dnnl_options;
+
+#if !defined(DNNL_ORT_THREAD)
+#if defined(_MSC_VER)
+    std::string ov_string = ToUTF8String(performance_test_config.run_config.ep_runtime_config_string);
+#else
+    std::string ov_string = performance_test_config.run_config.ep_runtime_config_string;
+#endif  // defined(_MSC_VER)
+    int num_threads = 0;
+    std::istringstream ss(ov_string);
+    std::string token;
+    while (ss >> token) {
+      if (token == "") {
+        continue;
+      }
+      auto pos = token.find("|");
+      if (pos == std::string::npos || pos == 0 || pos == token.length()) {
+        ORT_THROW(
+            "[ERROR] [OneDNN] Use a '|' to separate the key and value for the "
+            "run-time option you are trying to use.\n");
+      }
+
+      auto key = token.substr(0, pos);
+      auto value = token.substr(pos + 1);
+
+      if (key == "num_of_threads") {
+        std::stringstream sstream(value);
+        sstream >> num_threads;
+        if (num_threads < 0) {
+          ORT_THROW(
+              "[ERROR] [OneDNN] Invalid entry for the key 'num_of_threads',"
+              " set number of threads or use '0' for default\n");
+          // If the user doesnt define num_threads, auto detect threads later
+        }
+      } else {
+        ORT_THROW(
+            "[ERROR] [OneDNN] wrong key type entered. "
+            "Choose from the following runtime key options that are available for OneDNN. ['num_of_threads']\n");
+      }
+    }
+    dnnl_options.threadpool_args = static_cast<void*>(&num_threads);
+#endif  // !defined(DNNL_ORT_THREAD)
+    dnnl_options.use_arena = performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0;
+
     Ort::ThrowOnError(
-        OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options,
-                                                      performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0));
+        OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &dnnl_options));
 #else
     ORT_THROW("DNNL is not supported in this build\n");
 #endif

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -662,7 +662,9 @@ TEST_P(ModelTest, Run) {
       }
 #ifdef USE_DNNL
       else if (provider_name == "dnnl") {
-        ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_Dnnl(ortso, false));
+        OrtDnnlProviderOptions dnnl_options;
+        dnnl_options.use_arena = false;
+        ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_Dnnl(ortso, &dnnl_options));
       }
 #endif
       else if (provider_name == "tensorrt") {

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -107,7 +107,9 @@ static void TestInference(Ort::Env& env, const std::basic_string<ORTCHAR_T>& mod
 #endif
   } else if (provider_type == 2) {
 #ifdef USE_DNNL
-    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, 1));
+    OrtDnnlProviderOptions dnnl_options;
+    dnnl_options.use_arena = true;
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &dnnl_options));
     std::cout << "Running simple inference with dnnl provider" << std::endl;
 #else
     return;

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -110,12 +110,21 @@ std::unique_ptr<IExecutionProvider> DefaultCudaExecutionProvider() {
   return nullptr;
 }
 
-std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider(bool enable_arena) {
+std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider() {
 #ifdef USE_DNNL
-  if (auto factory = DnnlProviderFactoryCreator::Create(enable_arena ? 1 : 0))
+  OrtDnnlProviderOptions dnnl_options;
+  if (auto factory = DnnlProviderFactoryCreator::Create(&dnnl_options))
+    return factory->CreateProvider();
+#endif
+  return nullptr;
+}
+
+std::unique_ptr<IExecutionProvider> DnnlExecutionProviderWithOptions(const OrtDnnlProviderOptions* provider_options) {
+#ifdef USE_DNNL
+  if (auto factory = DnnlProviderFactoryCreator::Create(provider_options))
     return factory->CreateProvider();
 #else
-  ORT_UNUSED_PARAMETER(enable_arena);
+  ORT_UNUSED_PARAMETER(provider_options);
 #endif
   return nullptr;
 }

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -13,7 +13,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_ArmNN(
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_CoreML(uint32_t);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Cuda(const OrtCUDAProviderOptions* provider_options);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Cuda(const OrtCUDAProviderOptionsV2* provider_options);
-std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int use_arena);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(const OrtDnnlProviderOptions* provider_options);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_MIGraphX(const OrtMIGraphXProviderOptions* params);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Nnapi(
     uint32_t flags, const optional<std::string>& partitioning_stop_ops_list);
@@ -36,7 +36,8 @@ namespace test {
 // unique_ptr providers with default values for session registration
 std::unique_ptr<IExecutionProvider> DefaultCpuExecutionProvider(bool enable_arena = true);
 std::unique_ptr<IExecutionProvider> DefaultCudaExecutionProvider();
-std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider(bool enable_arena = true);
+std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider();
+std::unique_ptr<IExecutionProvider> DnnlExecutionProviderWithOptions(const OrtDnnlProviderOptions* provider_options);
 //std::unique_ptr<IExecutionProvider> DefaultTvmExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultTensorrtExecutionProvider();
 std::unique_ptr<IExecutionProvider> TensorrtExecutionProviderWithOptions(const OrtTensorRTProviderOptions* params);

--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -171,7 +171,8 @@ Status ParseArguments(int argc, char* argv[], MnistParameters& params) {
 #ifdef USE_DNNL
     bool use_dnnl = flags.count("use_dnnl") > 0;
     if (use_dnnl) {
-      params.providers.emplace(kDnnlExecutionProvider, DnnlProviderFactoryCreator::Create(1));
+      OrtDnnlProviderOptions dnnl_options;
+      params.providers.emplace(kDnnlExecutionProvider, DnnlProviderFactoryCreator::Create(&dnnl_options));
     }
 #endif
 

--- a/orttraining/orttraining/test/gradient/gradient_op_test_utils.cc
+++ b/orttraining/orttraining/test/gradient/gradient_op_test_utils.cc
@@ -146,7 +146,7 @@ void GradientOpTester::Run(
         else if (entry->Type() == onnxruntime::kCudaExecutionProvider)
           execution_provider = DefaultCudaExecutionProvider();
         else if (entry->Type() == onnxruntime::kDnnlExecutionProvider)
-          execution_provider = DefaultDnnlExecutionProvider(1);
+          execution_provider = DefaultDnnlExecutionProvider();
         else if (entry->Type() == onnxruntime::kTensorrtExecutionProvider)
           execution_provider = DefaultTensorrtExecutionProvider();
         // skip if execution provider is disabled


### PR DESCRIPTION
* Added the OrtDnnlProviderOptions structure to expose configuration options to the user

* The number of threads can be defined by the user with the -i flag on the perftest

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


